### PR TITLE
jquery-icheck is out of beta, fixed version number in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "bootswatch": "3.2.0+3",
     "font-awesome": "4.2.0",
     "spin.js": "2.0.1",
-    "jquery-icheck": "2.x-beta"
+    "jquery-icheck": "2.x"
   },
   "overrides": {
     "bootstrap-social": {


### PR DESCRIPTION
npm install fails because of a wrong version declaration in jquery-icheck