### PR TITLE
Make lang attribute depend on Vanillas locale

### DIFF
--- a/views/default.master.tpl
+++ b/views/default.master.tpl
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="sticky-footer-html">
+<html lang="{$CurrentLocale.Lang}" class="sticky-footer-html">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Replaced the fix "en" in html elements lang attribute with Vanillas current locale.