### PR TITLE
.TagCloud padding-left should be removed

### DIFF
--- a/less/components/labels.less
+++ b/less/components/labels.less
@@ -16,6 +16,10 @@
   &:extend(.label-info);
 }
 
+.TagCloud {
+  padding-left: 0;
+}
+
 .Note.Closed {
   display: inline-block;
   font-size: @font-size-base;


### PR DESCRIPTION
I found this problem in our bbs, I think it's better to remove .TagCloud's padding-left. Like the image showing below:

![http://img.vim-cn.com/93/6e758fd646e9f61af3662185651e55ce2e2f0e.jpg](http://img.vim-cn.com/93/6e758fd646e9f61af3662185651e55ce2e2f0e.jpg)

Sorry for I'm not that into less now, I'm not sure where and how to modify this, I think labels.less maybe the right place to add this rule...